### PR TITLE
chore(discord): use only one logging infrastructure

### DIFF
--- a/dibridge/discord.py
+++ b/dibridge/discord.py
@@ -152,4 +152,4 @@ class RelayDiscord(discord.Client):
 
 def start(token, channel_id):
     relay.DISCORD = RelayDiscord(channel_id)
-    relay.DISCORD.run(token)
+    relay.DISCORD.run(token, log_handler=None)


### PR DESCRIPTION
Otherwise we get every log message from Discord twice, which is
somewhat annoying.