### PR TITLE
feat(irc): disconnect IRC puppets 3 hours after the Discord user went offline

### DIFF
--- a/dibridge/discord.py
+++ b/dibridge/discord.py
@@ -72,6 +72,8 @@ class RelayDiscord(discord.Client):
         if message.type not in (discord.MessageType.default, discord.MessageType.reply):
             return
 
+        relay.IRC.update_status(message.author.id, message.author.status == discord.Status.offline)
+
         content = message.content
 
         if message.type == discord.MessageType.reply:
@@ -134,6 +136,9 @@ class RelayDiscord(discord.Client):
                 # Split the message in lines of at most 470 characters, breaking on words.
                 for line in textwrap.wrap(full_line.strip(), 470):
                     relay.IRC.send_message(message.author.id, message.author.name, line)
+
+    async def on_presence_update(self, before, after):
+        relay.IRC.update_status(after.id, after.status == discord.Status.offline)
 
     async def on_error(self, event, *args, **kwargs):
         log.exception("on_error(%s): %r / %r", event, args, kwargs)


### PR DESCRIPTION
```
When someone says something in the IRC bridge channel on Discord,
they will get an IRC presence. This IRC puppet will remain connected
until

- 3 hours after the Discord user went offline/invisible.

OR

- 3 hours after the Discord user said anything in the IRC bridged
  channel after going invisible.

Which ever comes last. This three hour grace period is to comply
more with the usage of Discord on mobile. Users tend to come online,
say something, go offline. And repeat this a few time during the
conversation.
```

The three hours is completely arbitrary. One hour felt short, six hours too long.
This way most IRC puppets will disconnect over night, which is a good thing and a bad thing, depending on the type of IRC user you were. For those people who connect to IRC when they want to participate in the chat, this is similar. For those people who use bouncers to be online 24/7 on IRC, this is different. Either way, a compromise had to be made.

On a small side-note, one drawback of this method is, that if the Discord user doesn't speak in the IRC channel when they come online, IRC won't see that they did. So there can be some confusion on the IRC side whether someone is online or not.

A possible mitigation would be to track how active a Discord user is on IRC, and be more relaxed about this 3 hours if they are more active. As basically the whole reason this PR exists is to make sure that one-time speakers don't idle on IRC for ever till the bridge reboots.

PS: important note, OFTC for example only allows 50 active connections from a /64 IPv6 range. This helps in making sure we stay below that threshold.
PPS: this makes upgrading the bridge slightly easier, as it is really likely that early in the morning nobody is connected anymore, and it can safely be upgraded.