### PR TITLE
feat(irc): disconnect IRC puppets a while after the Discord user went offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Options:
                                 (2001:A:B:C:D::/80)
   --irc-ignore-list TEXT        IRC nicknames to not relay messages for (comma
                                 separated, case-insensitive).
+  --irc-idle_timeout INTEGER    IRC puppet idle timeout, in seconds (default:
+                                2 days).
   -h, --help                    Show this message and exit.
 ```
 

--- a/dibridge/__main__.py
+++ b/dibridge/__main__.py
@@ -24,8 +24,22 @@ log = logging.getLogger(__name__)
 @click.option("--irc-channel", help="IRC channel to relay to, without the first '#'.", required=True)
 @click.option("--irc-puppet-ip-range", help="An IPv6 CIDR range to use for IRC puppets. (2001:A:B:C:D::/80)")
 @click.option("--irc-ignore-list", help="IRC nicknames to not relay messages for (comma separated, case-insensitive).")
+@click.option(
+    "--irc-idle-timeout",
+    help="IRC puppet idle timeout, in seconds (default: 2 days).",
+    default=60 * 60 * 24 * 2,
+    type=int,
+)
 def main(
-    discord_token, discord_channel_id, irc_host, irc_port, irc_nick, irc_channel, irc_puppet_ip_range, irc_ignore_list
+    discord_token,
+    discord_channel_id,
+    irc_host,
+    irc_port,
+    irc_nick,
+    irc_channel,
+    irc_puppet_ip_range,
+    irc_ignore_list,
+    irc_idle_timeout,
 ):
     if irc_puppet_ip_range:
         irc_puppet_ip_range = ipaddress.ip_network(irc_puppet_ip_range)
@@ -39,7 +53,8 @@ def main(
 
     thread_d = threading.Thread(target=discord.start, args=[discord_token, discord_channel_id])
     thread_i = threading.Thread(
-        target=irc.start, args=[irc_host, irc_port, irc_nick, f"#{irc_channel}", irc_puppet_ip_range, irc_ignore_list]
+        target=irc.start,
+        args=[irc_host, irc_port, irc_nick, f"#{irc_channel}", irc_puppet_ip_range, irc_ignore_list, irc_idle_timeout],
     )
 
     thread_d.start()

--- a/dibridge/discord.py
+++ b/dibridge/discord.py
@@ -72,6 +72,8 @@ class RelayDiscord(discord.Client):
         if message.type not in (discord.MessageType.default, discord.MessageType.reply):
             return
 
+        relay.IRC.update_status(message.author.id, message.author.status == discord.Status.offline)
+
         content = message.content
 
         if message.type == discord.MessageType.reply:
@@ -134,6 +136,9 @@ class RelayDiscord(discord.Client):
                 # Split the message in lines of at most 470 characters, breaking on words.
                 for line in textwrap.wrap(full_line.strip(), 470):
                     relay.IRC.send_message(message.author.id, message.author.name, line)
+
+    async def on_presence_update(self, before, after):
+        relay.IRC.update_status(after.id, after.status == discord.Status.offline)
 
     async def on_error(self, event, *args, **kwargs):
         log.exception("on_error(%s): %r / %r", event, args, kwargs)

--- a/dibridge/irc.py
+++ b/dibridge/irc.py
@@ -1,5 +1,6 @@
 import asyncio
 import irc.client_aio
+import functools
 import hashlib
 import logging
 import re
@@ -11,9 +12,14 @@ from . import relay
 
 log = logging.getLogger(__name__)
 
+# When a user on IRC was talking but left within 10 minutes, announce
+# this on Discord. This to prevent Discord users thinking they can still
+# talk to someone if they are in an active conversation with them.
+LEFT_WHILE_TALKING_TIMEOUT = 60 * 10
+
 
 class IRCRelay(irc.client_aio.AioSimpleIRCClient):
-    def __init__(self, host, port, nickname, channel, puppet_ip_range, ignore_list):
+    def __init__(self, host, port, nickname, channel, puppet_ip_range, ignore_list, idle_timeout):
         irc.client.SimpleIRCClient.__init__(self)
 
         self._loop = asyncio.get_event_loop()
@@ -29,6 +35,7 @@ class IRCRelay(irc.client_aio.AioSimpleIRCClient):
         self._puppet_ip_range = puppet_ip_range
         self._pinger_task = None
         self._ignore_list = ignore_list
+        self._idle_timeout = idle_timeout
 
         # List of users when they have last spoken.
         self._users_spoken = {}
@@ -104,7 +111,7 @@ class IRCRelay(irc.client_aio.AioSimpleIRCClient):
             return
 
         # If the user spoken recently, show on Discord the user left.
-        if self._users_spoken.get(nick, 0) > time.time() - 60 * 10:
+        if self._users_spoken.get(nick, 0) > time.time() - LEFT_WHILE_TALKING_TIMEOUT:
             self._users_spoken.pop(nick)
             relay.DISCORD.send_message(nick, "_left the IRC channel_")
 
@@ -149,7 +156,13 @@ class IRCRelay(irc.client_aio.AioSimpleIRCClient):
             ipv6_address = self._puppet_ip_range[self._generate_ipv6_bits(sanitized_discord_username)]
 
             self._puppets[discord_id] = IRCPuppet(
-                self._host, self._port, ipv6_address, sanitized_discord_username, self._channel
+                self._host,
+                self._port,
+                ipv6_address,
+                sanitized_discord_username,
+                self._channel,
+                functools.partial(self._remove_puppet, discord_id),
+                self._idle_timeout,
             )
             asyncio.create_task(self._puppets[discord_id].connect())
 
@@ -215,6 +228,9 @@ class IRCRelay(irc.client_aio.AioSimpleIRCClient):
     async def _stop(self):
         sys.exit(1)
 
+    async def _remove_puppet(self, discord_id):
+        self._puppets.pop(discord_id)
+
     # Thread safe wrapper around functions
 
     def get_status(self):
@@ -234,6 +250,20 @@ class IRCRelay(irc.client_aio.AioSimpleIRCClient):
 
         return self._puppets[discord_id]._nickname
 
+    def update_status(self, discord_id, is_offline):
+        if discord_id not in self._puppets:
+            return
+
+        if self._puppets[discord_id].is_offline() == is_offline:
+            return
+
+        if is_offline:
+            # Start a timer to delete the puppet after timeout.
+            asyncio.run_coroutine_threadsafe(self._puppets[discord_id].start_idle_timeout(), self._loop)
+        else:
+            # Stop the timer if the user comes back.
+            asyncio.run_coroutine_threadsafe(self._puppets[discord_id].stop_idle_timeout(), self._loop)
+
     def send_message(self, discord_id, discord_username, message):
         asyncio.run_coroutine_threadsafe(self._send_message(discord_id, discord_username, message), self._loop)
 
@@ -246,10 +276,10 @@ class IRCRelay(irc.client_aio.AioSimpleIRCClient):
         asyncio.run_coroutine_threadsafe(self._stop(), self._loop)
 
 
-def start(host, port, name, channel, puppet_ip_range, ignore_list):
+def start(host, port, name, channel, puppet_ip_range, ignore_list, idle_timeout):
     asyncio.set_event_loop(asyncio.new_event_loop())
 
-    relay.IRC = IRCRelay(host, port, name, channel, puppet_ip_range, ignore_list)
+    relay.IRC = IRCRelay(host, port, name, channel, puppet_ip_range, ignore_list, idle_timeout)
 
     log.info("Connecting to IRC ...")
     asyncio.get_event_loop().run_until_complete(relay.IRC._connect())

--- a/dibridge/irc_puppet.py
+++ b/dibridge/irc_puppet.py
@@ -5,7 +5,7 @@ import socket
 
 
 class IRCPuppet(irc.client_aio.AioSimpleIRCClient):
-    def __init__(self, irc_host, irc_port, ipv6_address, nickname, channel):
+    def __init__(self, irc_host, irc_port, ipv6_address, nickname, channel, remove_puppet_func, idle_timeout):
         irc.client.SimpleIRCClient.__init__(self)
 
         self.loop = asyncio.get_event_loop()
@@ -19,6 +19,10 @@ class IRCPuppet(irc.client_aio.AioSimpleIRCClient):
         self._joined = False
         self._channel = channel
         self._pinger_task = None
+        self._remove_puppet_func = remove_puppet_func
+        self._idle_timeout = idle_timeout
+        self._idle_task = None
+        self._reconnect = True
 
         self._connected_event = asyncio.Event()
         self._connected_event.clear()
@@ -87,8 +91,9 @@ class IRCPuppet(irc.client_aio.AioSimpleIRCClient):
         if self._pinger_task:
             self._pinger_task.cancel()
 
-        # Start a task to reconnect us.
-        asyncio.create_task(self.connect())
+        if self._reconnect:
+            # Start a task to reconnect us.
+            asyncio.create_task(self.connect())
 
     def _left(self, nick):
         # If we left the channel, rejoin.
@@ -102,6 +107,13 @@ class IRCPuppet(irc.client_aio.AioSimpleIRCClient):
         while True:
             await asyncio.sleep(120)
             self._client.ping("keep-alive")
+
+    async def _idle_timeout_task(self):
+        await asyncio.sleep(self._idle_timeout)
+
+        self._reconnect = False
+        self._client.disconnect("User went offline on Discord a while ago")
+        await self._remove_puppet_func()
 
     async def reclaim_nick(self):
         # We sleep for a second, as it turns out, if we are quick enough to change
@@ -118,7 +130,7 @@ class IRCPuppet(irc.client_aio.AioSimpleIRCClient):
 
         local_addr = (str(self._ipv6_address), 0)
 
-        while True:
+        while self._reconnect:
             try:
                 await self.connection.connect(
                     self._irc_host,
@@ -135,10 +147,36 @@ class IRCPuppet(irc.client_aio.AioSimpleIRCClient):
                 # When we can't connect, try again in 5 seconds.
                 await asyncio.sleep(5)
 
+    async def start_idle_timeout(self):
+        await self.stop_idle_timeout()
+        self._idle_task = asyncio.create_task(self._idle_timeout_task())
+
+    async def stop_idle_timeout(self):
+        if not self._idle_task:
+            return
+
+        self._idle_task.cancel()
+        self._idle_task = None
+
+    async def _reset_idle_timeout(self):
+        if not self._idle_task:
+            return
+
+        # User is talking while appearing offline. Constantly reset the idle timeout.
+        await self.stop_idle_timeout()
+        await self.start_idle_timeout()
+
+    def is_offline(self):
+        return self._idle_task is not None
+
     async def send_message(self, content):
+        await self._reset_idle_timeout()
+
         await self._connected_event.wait()
         self._client.privmsg(self._channel, content)
 
     async def send_action(self, content):
+        await self._reset_idle_timeout()
+
         await self._connected_event.wait()
         self._client.action(self._channel, content)


### PR DESCRIPTION
When a Discord user is marked as offline, they will disconnect from IRC after a configurable timeout. Additionally, as offline can also mean the user is invisible, this countdown is reset every time a user talks while being offline.

Depending on your network, the right timeout might vary. It is advisible to use a long time, like more than a day. This works best for users that want to be online on IRC all day every day, and still have a decent night sleep. Additionally, for people that don't actually care, also no harm is done.

Because of this, a default value of 48 hours is set.

This is a revive of #47.