### PR TITLE
feat(irc): on kill, don't reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ ip route add local 2001:db8:100::/80 dev lo
 
 (don't forget to use as `--irc-host` something that also resolves to a local IPv6, like `localhost`)
 
+By default, the `oper` is named `dusty` with as password `IAmDusty`.
+
 ### Discord bot
 
 To connect to Discord, one could register their own Discord bot, invite it to a private server, and create a dedicated channel for testing.

--- a/dibridge/irc_puppet.py
+++ b/dibridge/irc_puppet.py
@@ -75,6 +75,14 @@ class IRCPuppet(irc.client_aio.AioSimpleIRCClient):
             return
         self._left(event.arguments[0])
 
+    def on_kill(self, _client, event):
+        # If a user is killed, the ops on IRC must have a good reason.
+        # So we disconnect the bridge on our side too.
+        self._log.info("Killed by server; removing puppet")
+
+        self._reconnect = False
+        asyncio.create_task(self._remove_puppet_func())
+
     def on_nick(self, client, event):
         if event.source.nick == self._nickname:
             # Sometimes happens on a netsplit, or when a username is GHOSTed.


### PR DESCRIPTION
When a puppet is killed on IRC, it means an oper stepped in and didn't appreciate what the puppet was saying. Don't annoy the IRC oper by reconnecting.

This is only really used in cases of spambots; although they are banned on Discord really quick, IRC doesn't see that, and they rightfully take their own action. So respond to that in a way that indicates we acknowledged the request.