### PR TITLE
fix(irc): also indicate a user left IRC on QUIT too

### DIFF
--- a/dibridge/irc.py
+++ b/dibridge/irc.py
@@ -96,6 +96,9 @@ class IRCRelay(irc.client_aio.AioSimpleIRCClient):
             return
         self._left(event.arguments[0])
 
+    def on_quit(self, _client, event):
+        self._left(event.source.nick)
+
     def on_disconnect(self, _client, event):
         log.error("Disconnected from IRC")
         self._joined = False


### PR DESCRIPTION
Before this change, it was only indicated on PART, which happens rarely.