### PR TITLE
fix(irc): prevent async-tasks to be garbage-collected too early

### DIFF
--- a/dibridge/irc.py
+++ b/dibridge/irc.py
@@ -7,6 +7,8 @@ import re
 import sys
 import time
 
+from openttd_helpers.asyncio_helper import enable_strong_referenced_tasks
+
 from .irc_puppet import IRCPuppet
 from . import relay
 
@@ -278,7 +280,9 @@ class IRCRelay(irc.client_aio.AioSimpleIRCClient):
 
 
 def start(host, port, name, channel, puppet_ip_range, puppet_postfix, ignore_list, idle_timeout):
-    asyncio.set_event_loop(asyncio.new_event_loop())
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    enable_strong_referenced_tasks(loop)
 
     relay.IRC = IRCRelay(host, port, name, channel, puppet_ip_range, puppet_postfix, ignore_list, idle_timeout)
 


### PR DESCRIPTION
Python only keeps a weak-reference to tasks created, so when the GC comes by, it can remove tasks that are not assigned to a variable.
The async-helper changes the factory to always store a strong reference, avoiding this issue.