### PR TITLE
fix(irc): usernames are not allowed to start with _

### DIFF
--- a/dibridge/irc.py
+++ b/dibridge/irc.py
@@ -129,10 +129,16 @@ class IRCRelay(irc.client_aio.AioSimpleIRCClient):
     async def _connect(self):
         while True:
             try:
+                username = self._nickname
+                # An additional constraints usernames have over nicknames, that they are
+                # also not allowed to start with an underscore.
+                username = re.sub(r"^_+", "", username)
+
                 await self.connection.connect(
                     self._host,
                     self._port,
                     self._nickname,
+                    username=username,
                     connect_factory=irc.connection.AioFactory(ssl=self._port == 6697),
                 )
                 break


### PR DESCRIPTION
Purely found by experimentation, but it seems usernames cannot start with `_`. If there are any other exceptions, I do not know. From what I can read in the RFCs, it is not specified what the conditions for `username` actually are. So hopefully this is fine?