### PR TITLE
feat(irc): allow setting a small ip-range for puppets

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ First of all, you need Linux 4.3+ for this to work.
 Next, you need to have an IPv6 prefix, of which you can delegate a part to this bridge.
 
 All decent ISPs these days can assign you an IPv6 prefix, mostly a `/64` or better.
-We only need a `/80` for this, so that is fine.
+We only need a `/80` for this (or at least a `/96`), so that is fine.
 Similar, cloud providers also offer assigning IPv6 prefixes to VMs.
 For example [AWS allows you to assign a `/80` to a single VM](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-prefix-eni.html).
 

--- a/dibridge/__main__.py
+++ b/dibridge/__main__.py
@@ -45,8 +45,8 @@ def main(
 ):
     if irc_puppet_ip_range:
         irc_puppet_ip_range = ipaddress.ip_network(irc_puppet_ip_range)
-        if irc_puppet_ip_range.num_addresses < 2**48:
-            raise Exception("--irc-puppet-ip-range needs to be an IPv6 CIDR range of at least /80 or more.")
+        if irc_puppet_ip_range.num_addresses < 2**32:
+            raise Exception("--irc-puppet-ip-range needs to be an IPv6 CIDR range of at least /64 or more.")
 
     if irc_ignore_list:
         irc_ignore_list = [nickname.strip().lower() for nickname in irc_ignore_list.split(",") if nickname.strip()]

--- a/dibridge/irc.py
+++ b/dibridge/irc.py
@@ -241,12 +241,15 @@ class IRCRelay(irc.client_aio.AioSimpleIRCClient):
         return discord_username
 
     def _generate_ipv6_bits(self, discord_username):
-        # Based on the Discord username, generate 48 bits to add to the IPv6 address.
+        # Based on the Discord username, generate N bits to add to the IPv6 address.
         # This way we do not have to persistently store any information, but every user
         # will always have the same IPv6.
-        # For the 48 bits, we simply take the first 48 bits from the SHA-256 hash of the
+        # For the N bits, we simply take the last N bits from the SHA-256 hash of the
         # username. Chances on collision are really low.
-        return int(hashlib.sha256(discord_username.encode("utf-8")).hexdigest(), 16) % (1 << 48)
+        # N here is the length of the IPv6 range assigned.
+        return (
+            int(hashlib.sha256(discord_username.encode("utf-8")).hexdigest(), 16) % self._puppet_ip_range.num_addresses
+        )
 
     async def _stop(self):
         sys.exit(1)


### PR DESCRIPTION
On AWS, it is impractical to set a /80 up; a /84 for example is way easier. And the chances on collision are still really low. Of course, the smaller range, the more likely it becomes. So at least a /96 is required.